### PR TITLE
feat: add telegram notification endpoint

### DIFF
--- a/WeYuTelegramNotify/Controllers/NotifyController.cs
+++ b/WeYuTelegramNotify/Controllers/NotifyController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using WeYuTelegramNotify.Models;
+using WeYuTelegramNotify.Services;
+
+namespace WeYuTelegramNotify.Controllers;
+
+[ApiController]
+[Route("api/notify")]
+public class NotifyController : ControllerBase
+{
+    private readonly ITelegramNotifyService _telegramService;
+
+    public NotifyController(ITelegramNotifyService telegramService)
+    {
+        _telegramService = telegramService;
+    }
+
+    [HttpPost("telegram")]
+    public async Task<IActionResult> PostTelegram([FromBody] TelegramNotifyRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var requestId = Guid.NewGuid();
+        try
+        {
+            await _telegramService.SendAsync(request, cancellationToken);
+            return Accepted(new { requestId });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(502, new { error = ex.Message, requestId });
+        }
+    }
+}
+

--- a/WeYuTelegramNotify/Models/TelegramNotifyRequest.cs
+++ b/WeYuTelegramNotify/Models/TelegramNotifyRequest.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WeYuTelegramNotify.Models;
+
+public class TelegramNotifyRequest
+{
+    [Required]
+    public string Subject { get; set; } = string.Empty;
+
+    [Required]
+    public string Body { get; set; } = string.Empty;
+
+    [Required]
+    public long GroupId { get; set; }
+
+    public string ParseMode { get; set; } = "HTML";
+}
+

--- a/WeYuTelegramNotify/Options/TelegramBotOptions.cs
+++ b/WeYuTelegramNotify/Options/TelegramBotOptions.cs
@@ -1,0 +1,8 @@
+namespace WeYuTelegramNotify.Options;
+
+public class TelegramBotOptions
+{
+    public string BaseUrl { get; set; } = string.Empty;
+    public string BotToken { get; set; } = string.Empty;
+}
+

--- a/WeYuTelegramNotify/Services/ITelegramNotifyService.cs
+++ b/WeYuTelegramNotify/Services/ITelegramNotifyService.cs
@@ -1,0 +1,9 @@
+using WeYuTelegramNotify.Models;
+
+namespace WeYuTelegramNotify.Services;
+
+public interface ITelegramNotifyService
+{
+    Task SendAsync(TelegramNotifyRequest request, CancellationToken cancellationToken = default);
+}
+

--- a/WeYuTelegramNotify/Services/TelegramNotifyService.cs
+++ b/WeYuTelegramNotify/Services/TelegramNotifyService.cs
@@ -1,0 +1,48 @@
+using System.Net.Http.Json;
+using WeYuTelegramNotify.Models;
+
+namespace WeYuTelegramNotify.Services;
+
+public class TelegramNotifyService : ITelegramNotifyService
+{
+    private const int MaxMessageLength = 4096;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public TelegramNotifyService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task SendAsync(TelegramNotifyRequest request, CancellationToken cancellationToken = default)
+    {
+        var client = _httpClientFactory.CreateClient("Telegram");
+        var header = $"<b>{request.Subject}</b>\n\n";
+        var maxBodyLength = MaxMessageLength - header.Length;
+        foreach (var chunk in SplitMessage(request.Body, maxBodyLength))
+        {
+            var payload = new Dictionary<string, string>
+            {
+                ["chat_id"] = request.GroupId.ToString(),
+                ["text"] = header + chunk,
+                ["parse_mode"] = request.ParseMode
+            };
+
+            using var content = new FormUrlEncodedContent(payload);
+            using var response = await client.PostAsync("sendMessage", content, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                throw new HttpRequestException($"Telegram API error: {response.StatusCode} - {body}");
+            }
+        }
+    }
+
+    private static IEnumerable<string> SplitMessage(string text, int chunkSize)
+    {
+        for (var i = 0; i < text.Length; i += chunkSize)
+        {
+            yield return text.Substring(i, Math.Min(chunkSize, text.Length - i));
+        }
+    }
+}
+

--- a/WeYuTelegramNotify/appsettings.json
+++ b/WeYuTelegramNotify/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "TelegramBot": {
+    "BaseUrl": "https://api.telegram.org/bot",
+    "BotToken": ""
+  }
 }


### PR DESCRIPTION
## Summary
- add Telegram notification request model and options
- implement service to send messages via Telegram Bot API with 4096-char splitting
- expose POST /api/notify/telegram endpoint

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ad68d5a1608320adb1a7a178b3da20