### PR TITLE
feat: add email logging

### DIFF
--- a/WeYuTelegramNotify/Controllers/NotifyController.cs
+++ b/WeYuTelegramNotify/Controllers/NotifyController.cs
@@ -1,4 +1,4 @@
-using System.Web;
+using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using WeYuTelegramNotify.interfaces;
 using WeYuTelegramNotify.Models;
@@ -13,218 +13,190 @@ public class NotifyController : ControllerBase
     private readonly IEmailNotifyService _emailNotifyService;
     private readonly ILogger<NotifyController> _logger;
 
-    public NotifyController(ILogger<NotifyController> logger, ITelegramNotifyService telegramService, IEmailNotifyService emailNotifyService)
+    public NotifyController(
+        ILogger<NotifyController> logger,
+        ITelegramNotifyService telegramService,
+        IEmailNotifyService emailNotifyService)
     {
         _logger = logger;
         _telegramService = telegramService;
         _emailNotifyService = emailNotifyService;
     }
 
-    [HttpGet("telegram")]
-    public Task<IActionResult> GetTelegram([FromQuery] TelegramNotifyRequest request, CancellationToken cancellationToken)
-        => SendTelegramAsync(request, cancellationToken);
-    
-    /// <summary>
-    /// 單一發信
-    /// </summary>
-    /// <param name="request"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    [HttpGet("singleEmail")]
-    public Task<IActionResult> SendEmail([FromQuery] EmailNotifyRequest request, CancellationToken cancellationToken)
-        => SendEmailAsync(request, cancellationToken);
+    // ----------------------
+    // Telegram
+    // ----------------------
 
-    /// <summary>
-    /// 依群組發信
-    /// </summary>
-    /// <param name="request"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    [HttpGet("groupEmail")]
-    public Task<IActionResult> SendGroupEmail([FromQuery] GroupEmailNotifyRequest request, CancellationToken cancellationToken)
-        => SendGroupEmailAsync(request, cancellationToken);
-
-    private async Task<IActionResult> SendTelegramAsync(TelegramNotifyRequest request, CancellationToken cancellationToken)
-    {
-        // ---- 建立可追蹤的 scope：把 requestId / route / user-agent 等塞進 scope，之後每筆 log 都會帶到 ----
-        var requestId = HttpContext.Request.Headers.TryGetValue("X-Request-Id", out var rid)
-                        ? rid.ToString()
-                        : HttpContext.TraceIdentifier;
-
-        using var scope = _logger.BeginScope(new Dictionary<string, object?>
-        {
-            ["requestId"]   = requestId,
-            ["route"]       = HttpContext.Request.Path.Value,
-            ["method"]      = HttpContext.Request.Method,
-            ["remoteIp"]    = HttpContext.Connection.RemoteIpAddress?.ToString(),
-            ["userAgent"]   = HttpContext.Request.Headers.UserAgent.ToString()
-        });
-
-        var startedAt = DateTimeOffset.UtcNow;
-
-        try
-        {
-            // ---- 紀錄收到請求（避免敏感資訊外洩，訊息內容採長度/哈希或摘要而非原文）----
-            _logger.LogInformation("Incoming telegram notify request: {Summary}",
-                BuildRequestSummarySafe(request));
-
-            if (!ModelState.IsValid)
+    /// <summary>（POST 推薦）發送 Telegram 訊息</summary>
+    [HttpPost("telegram")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public Task<IActionResult> PostTelegram([FromBody] TelegramNotifyRequest request, CancellationToken ct)
+        => HandleAsync(
+            request,
+            summaryBuilder: BuildRequestSummarySafe,
+            doSendAsync: _telegramService.SendAsync,
+            success: r => Ok(new
             {
-                // 把 ModelState 錯誤展平成 list，利於查詢
-                var errors = ModelState
-                    .Where(kv => kv.Value?.Errors?.Count > 0)
-                    .Select(kv => new
-                    {
-                        Field = kv.Key,
-                        Messages = kv.Value!.Errors.Select(e => e.ErrorMessage).ToArray()
-                    })
-                    .ToArray();
-
-                _logger.LogWarning("Validation failed: {Errors}", errors);
-
-                return ValidationProblem(ModelState);
-            }
-
-            var result = await _telegramService.SendAsync(request, cancellationToken);
-
-            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-
-            if (result.Success)
+                message = "sent",
+                subject = r.Subject,
+                bodyPreview = r.Body,
+                logId = r.LogId
+            }),
+            failure: r =>
             {
-                _logger.LogInformation(
-                    "Telegram sent successfully. logId={LogId}, subject={Subject}, elapsedMs={Elapsed}",
-                    result.LogId, result.Subject, elapsedMs);
-
-                return Ok(new
+                var status = r.Stage switch
                 {
-                    message = "sent",
-                    subject = result.Subject,
-                    body = HttpUtility.HtmlDecode(result.Body), // 給前端回預覽（若要避免 XSS，建議僅回純文字或加上 allow-list）
-                    logId = result.LogId
+                    FailureStage.Validation => StatusCodes.Status400BadRequest,
+                    FailureStage.HttpSend   => StatusCodes.Status502BadGateway,
+                    FailureStage.DbWrite    => StatusCodes.Status500InternalServerError,
+                    _                       => StatusCodes.Status500InternalServerError
+                };
+                return StatusCode(status, new
+                {
+                    message = "failed",
+                    stage = r.Stage?.ToString(),
+                    error = r.Error,
+                    httpStatus = r.HttpStatus,
+                    logId = r.LogId
                 });
+            },
+            ct);
+
+    /// <summary>（向後相容）GET 版 Telegram 發送：建議改用 POST</summary>
+    [HttpGet("telegram")]
+    public Task<IActionResult> GetTelegram([FromQuery] TelegramNotifyRequest request, CancellationToken ct)
+        => PostTelegram(request, ct);
+
+    // ----------------------
+    // 單一 Email
+    // ----------------------
+
+    /// <summary>（POST 推薦）單一 Email 發送</summary>
+    [HttpPost("email")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public Task<IActionResult> PostEmail([FromBody] EmailNotifyRequest request, CancellationToken ct)
+        => HandleAsync(
+            request,
+            summaryBuilder: BuildEmailRequestSummarySafe,
+            doSendAsync: _emailNotifyService.SendAsync,
+            success: r => Ok(new { message = "sent", logId = r.LogId }),
+            failure: r => StatusCode(StatusCodes.Status400BadRequest, new
+            {
+                message = "failed",
+                error = r.Error,
+                logId = r.LogId
+            }),
+            ct);
+
+    /// <summary>（向後相容）GET 版單一 Email：建議改用 POST</summary>
+    [HttpGet("singleEmail")]
+    public Task<IActionResult> GetEmail([FromQuery] EmailNotifyRequest request, CancellationToken ct)
+        => PostEmail(request, ct);
+
+    // ----------------------
+    // 群組 Email
+    // ----------------------
+
+    /// <summary>（POST 推薦）依群組發信（支援父/子群組展開）</summary>
+    [HttpPost("groupEmail")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
+    public Task<IActionResult> PostGroupEmail([FromBody] GroupEmailNotifyRequest request, CancellationToken ct)
+        => HandleAsync(
+            request,
+            summaryBuilder: BuildGroupEmailRequestSummarySafe,
+            doSendAsync: _emailNotifyService.SendGroupAsync,
+            success: r => Ok(new { message = "sent", count = r.SentCount, logId = r.LogId }),
+            failure: r => StatusCode(StatusCodes.Status400BadRequest, new
+            {
+                message = "failed",
+                error = r.Error,
+                logId = r.LogId
+            }),
+            ct);
+
+    /// <summary>（向後相容）GET 版群組 Email：建議改用 POST</summary>
+    [HttpGet("groupEmail")]
+    public Task<IActionResult> GetGroupEmail([FromQuery] GroupEmailNotifyRequest request, CancellationToken ct)
+        => PostGroupEmail(request, ct);
+
+    // ----------------------
+    // 共用樣板：Scope + 驗證 + 例外處理 + 統一記錄
+    // ----------------------
+
+    private async Task<IActionResult> HandleAsync<TRequest, TResult>(
+        TRequest request,
+        Func<TRequest, object> summaryBuilder,
+        Func<TRequest, CancellationToken, Task<TResult>> doSendAsync,
+        Func<TResult, IActionResult> success,
+        Func<TResult, IActionResult> failure,
+        CancellationToken ct)
+        where TRequest : class
+    {
+        // ---- 建 Scope（每個 log 都會帶這些欄位）----
+        var requestId = HttpContext.Request.Headers.TryGetValue("X-Request-Id", out var rid)
+            ? rid.ToString()
+            : HttpContext.TraceIdentifier;
+
+        using var scope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["requestId"] = requestId,
+            ["route"]     = HttpContext.Request.Path.Value,
+            ["method"]    = HttpContext.Request.Method,
+            ["remoteIp"]  = HttpContext.Connection.RemoteIpAddress?.ToString(),
+            ["userAgent"] = HttpContext.Request.Headers.UserAgent.ToString()
+        });
+
+        var startedAt = DateTimeOffset.UtcNow;
+
+        try
+        {
+            // `ApiController` 會自動驗證 ModelState，但我們想記錄更友善的 log
+            if (!ModelState.IsValid)
+            {
+                var errors = ModelState
+                    .Where(kv => kv.Value?.Errors?.Count > 0)
+                    .Select(kv => new
+                    {
+                        Field = kv.Key,
+                        Messages = kv.Value!.Errors.Select(e => e.ErrorMessage).ToArray()
+                    })
+                    .ToArray();
+
+                _logger.LogWarning("Validation failed: {Errors}", errors);
+                return ValidationProblem(ModelState);
             }
 
-            // 失敗依 Stage 分級 & 記錄更多上下文
-            var status = result.Stage switch
-            {
-                FailureStage.Validation => StatusCodes.Status400BadRequest,
-                FailureStage.HttpSend   => StatusCodes.Status502BadGateway,
-                FailureStage.DbWrite    => StatusCodes.Status500InternalServerError,
-                _                       => StatusCodes.Status500InternalServerError
-            };
+            _logger.LogInformation("Incoming request: {Summary}", summaryBuilder(request));
 
-            // 以嚴重度區分 log level
-            var logProps = new
-            {
-                result.Stage,
-                result.Error,
-                result.HttpStatus,
-                result.LogId,
-                elapsedMs
-            };
+            var result = await doSendAsync(request, ct).ConfigureAwait(false);
+            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
 
-            if (status >= 500)
+            // 反射抓取可能存在的 LogId / Stage / Error（服務層欄位命名不一致也能帶出來）
+            var logId   = result?.GetType().GetProperty("LogId")?.GetValue(result, null);
+            var stage   = result?.GetType().GetProperty("Stage")?.GetValue(result, null);
+            var successProp = result?.GetType().GetProperty("Success")?.GetValue(result, null) as bool?;
+
+            if (successProp == true)
             {
-                _logger.LogError("Telegram notify failed (server-side). {@Props}", logProps);
+                _logger.LogInformation("Send OK. logId={LogId}, elapsedMs={Elapsed}", logId, elapsedMs);
+                return success(result!);
             }
+
+            var error   = result?.GetType().GetProperty("Error")?.GetValue(result, null);
+            var httpSt  = result?.GetType().GetProperty("HttpStatus")?.GetValue(result, null);
+
+            // 失敗級別分流（Server 5xx / Upstream/Client 4xx）
+            if (stage?.ToString() is "HttpSend" or "Validation")
+                _logger.LogWarning("Send failed: stage={Stage}, error={Error}, http={Http}, logId={LogId}",
+                    stage, error, httpSt, logId);
             else
-            {
-                _logger.LogWarning("Telegram notify failed (client/upstream). {@Props}", logProps);
-            }
+                _logger.LogError("Send failed (server-side): stage={Stage}, error={Error}, http={Http}, logId={LogId}",
+                    stage, error, httpSt, logId);
 
-            return StatusCode(status, new
-            {
-                message = "failed",
-                stage = result.Stage?.ToString(),
-                error = result.Error,
-                httpStatus = result.HttpStatus,
-                logId = result.LogId
-            });
-        }
-        catch (OperationCanceledException)
-        {
-            // 取消也應有一致的紀錄
-            _logger.LogWarning("Request cancelled by client or server token.");
-            return StatusCode(StatusCodes.Status499ClientClosedRequest, new
-            {
-                message = "cancelled"
-            });
-        }
-        catch (Exception ex)
-        {
-            // 未預期例外：一定要 Fatal/Error 級別 + 帶 scope
-            _logger.LogError(ex, "Unhandled exception during telegram notify.");
-            return StatusCode(StatusCodes.Status500InternalServerError, new
-            {
-                message = "failed",
-                stage = "UnhandledException"
-            });
-        }
-        finally
-        {
-            var totalMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-            _logger.LogInformation("Request completed in {Elapsed} ms", totalMs);
-        }
-    }
-    
-    private async Task<IActionResult> SendEmailAsync(EmailNotifyRequest request, CancellationToken cancellationToken)
-    {
-        var requestId = HttpContext.Request.Headers.TryGetValue("X-Request-Id", out var rid)
-                        ? rid.ToString()
-                        : HttpContext.TraceIdentifier;
-
-        using var scope = _logger.BeginScope(new Dictionary<string, object?>
-        {
-            ["requestId"] = requestId,
-            ["route"] = HttpContext.Request.Path.Value,
-            ["method"] = HttpContext.Request.Method,
-            ["remoteIp"] = HttpContext.Connection.RemoteIpAddress?.ToString(),
-            ["userAgent"] = HttpContext.Request.Headers.UserAgent.ToString()
-        });
-
-        var startedAt = DateTimeOffset.UtcNow;
-
-        try
-        {
-            _logger.LogInformation("Incoming email notify request: {Summary}",
-                BuildEmailRequestSummarySafe(request));
-
-            if (!ModelState.IsValid)
-            {
-                var errors = ModelState
-                    .Where(kv => kv.Value?.Errors?.Count > 0)
-                    .Select(kv => new
-                    {
-                        Field = kv.Key,
-                        Messages = kv.Value!.Errors.Select(e => e.ErrorMessage).ToArray()
-                    })
-                    .ToArray();
-
-                _logger.LogWarning("Validation failed: {Errors}", errors);
-
-                return ValidationProblem(ModelState);
-            }
-
-            var result = await _emailNotifyService.SendAsync(request, cancellationToken);
-            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-
-            if (result.Success)
-            {
-                _logger.LogInformation(
-                    "Email sent successfully. logId={LogId}, to={Email}, subject={Subject}, elapsedMs={Elapsed}",
-                    result.LogId, request.Email, request.Subject, elapsedMs);
-
-                return Ok(new { message = "sent", logId = result.LogId });
-            }
-
-            _logger.LogWarning("Email notify failed: {Error}, logId={LogId}", result.Error, result.LogId);
-
-            return StatusCode(StatusCodes.Status400BadRequest, new
-            {
-                message = "failed",
-                error = result.Error,
-                logId = result.LogId
-            });
+            return failure(result!);
         }
         catch (OperationCanceledException)
         {
@@ -233,7 +205,7 @@ public class NotifyController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unhandled exception during email notify.");
+            _logger.LogError(ex, "Unhandled exception during notify.");
             return StatusCode(StatusCodes.Status500InternalServerError, new
             {
                 message = "failed",
@@ -247,129 +219,33 @@ public class NotifyController : ControllerBase
         }
     }
 
-    private async Task<IActionResult> SendGroupEmailAsync(GroupEmailNotifyRequest request, CancellationToken cancellationToken)
-    {
-        var requestId = HttpContext.Request.Headers.TryGetValue("X-Request-Id", out var rid)
-                        ? rid.ToString()
-                        : HttpContext.TraceIdentifier;
+    // ----------------------
+    // 安全的摘要/預覽建構
+    // ----------------------
 
-        using var scope = _logger.BeginScope(new Dictionary<string, object?>
-        {
-            ["requestId"] = requestId,
-            ["route"] = HttpContext.Request.Path.Value,
-            ["method"] = HttpContext.Request.Method,
-            ["remoteIp"] = HttpContext.Connection.RemoteIpAddress?.ToString(),
-            ["userAgent"] = HttpContext.Request.Headers.UserAgent.ToString()
-        });
-
-        var startedAt = DateTimeOffset.UtcNow;
-
-        try
-        {
-            _logger.LogInformation("Incoming group email notify request: {Summary}",
-                BuildGroupEmailRequestSummarySafe(request));
-
-            if (!ModelState.IsValid)
-            {
-                var errors = ModelState
-                    .Where(kv => kv.Value?.Errors?.Count > 0)
-                    .Select(kv => new
-                    {
-                        Field = kv.Key,
-                        Messages = kv.Value!.Errors.Select(e => e.ErrorMessage).ToArray()
-                    })
-                    .ToArray();
-
-                _logger.LogWarning("Validation failed: {Errors}", errors);
-
-                return ValidationProblem(ModelState);
-            }
-
-            var result = await _emailNotifyService.SendGroupAsync(request, cancellationToken);
-            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-
-            if (result.Success)
-            {
-                _logger.LogInformation(
-                    "Group email sent successfully. logId={LogId}, group={GroupId}, count={Count}, elapsedMs={Elapsed}",
-                    result.LogId, request.GroupId, result.SentCount, elapsedMs);
-
-                return Ok(new { message = "sent", count = result.SentCount, logId = result.LogId });
-            }
-
-            _logger.LogWarning("Group email notify failed: {Error}, logId={LogId}", result.Error, result.LogId);
-
-            return StatusCode(StatusCodes.Status400BadRequest, new
-            {
-                message = "failed",
-                error = result.Error,
-                logId = result.LogId
-            });
-        }
-        catch (OperationCanceledException)
-        {
-            _logger.LogWarning("Request cancelled by client or server token.");
-            return StatusCode(StatusCodes.Status499ClientClosedRequest, new { message = "cancelled" });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unhandled exception during group email notify.");
-            return StatusCode(StatusCodes.Status500InternalServerError, new
-            {
-                message = "failed",
-                stage = "UnhandledException"
-            });
-        }
-        finally
-        {
-            var totalMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
-            _logger.LogInformation("Request completed in {Elapsed} ms", totalMs);
-        }
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="req"></param>
-    /// <returns></returns>
     private static object BuildRequestSummarySafe(TelegramNotifyRequest req)
-    {
-        var bodyLength = req?.Body?.Length ?? 0;
-        var subjectLength = req?.Subject?.Length ?? 0;
-
-        return new
+        => new
         {
             req?.ChatId,
-            HasHtmlLikeTag = req?.Body?.Contains('<') == true,
-            SubjectLength = subjectLength,
-            BodyLength = bodyLength
+            SubjectLength = req?.Subject?.Length ?? 0,
+            BodyLength = req?.Body?.Length ?? 0,
+            HasHtmlLikeTag = req?.Body?.Contains('<') == true
         };
-    }
 
     private static object BuildEmailRequestSummarySafe(EmailNotifyRequest req)
-    {
-        var bodyLength = req?.Body?.Length ?? 0;
-        var subjectLength = req?.Subject?.Length ?? 0;
-
-        return new
+        => new
         {
             req?.Email,
-            HasHtmlLikeTag = req?.Body?.Contains('<') == true,
-            SubjectLength = subjectLength,
-            BodyLength = bodyLength
+            SubjectLength = req?.Subject?.Length ?? 0,
+            BodyLength = req?.Body?.Length ?? 0,
+            HasHtmlLikeTag = req?.Body?.Contains('<') == true
         };
-    }
 
     private static object BuildGroupEmailRequestSummarySafe(GroupEmailNotifyRequest req)
-    {
-        var bodyLength = req?.Body?.Length ?? 0;
-        var subjectLength = req?.Subject?.Length ?? 0;
-
-        return new
+        => new
         {
             req?.GroupId,
-            SubjectLength = subjectLength,
-            BodyLength = bodyLength
+            SubjectLength = req?.Subject?.Length ?? 0,
+            BodyLength = req?.Body?.Length ?? 0
         };
-    }
 }

--- a/WeYuTelegramNotify/Controllers/NotifyController.cs
+++ b/WeYuTelegramNotify/Controllers/NotifyController.cs
@@ -211,18 +211,19 @@ public class NotifyController : ControllerBase
             if (result.Success)
             {
                 _logger.LogInformation(
-                    "Email sent successfully. to={Email}, subject={Subject}, elapsedMs={Elapsed}",
-                    request.Email, request.Subject, elapsedMs);
+                    "Email sent successfully. logId={LogId}, to={Email}, subject={Subject}, elapsedMs={Elapsed}",
+                    result.LogId, request.Email, request.Subject, elapsedMs);
 
-                return Ok(new { message = "sent" });
+                return Ok(new { message = "sent", logId = result.LogId });
             }
 
-            _logger.LogWarning("Email notify failed: {Error}", result.Error);
+            _logger.LogWarning("Email notify failed: {Error}, logId={LogId}", result.Error, result.LogId);
 
             return StatusCode(StatusCodes.Status400BadRequest, new
             {
                 message = "failed",
-                error = result.Error
+                error = result.Error,
+                logId = result.LogId
             });
         }
         catch (OperationCanceledException)
@@ -290,18 +291,19 @@ public class NotifyController : ControllerBase
             if (result.Success)
             {
                 _logger.LogInformation(
-                    "Group email sent successfully. group={GroupId}, count={Count}, elapsedMs={Elapsed}",
-                    request.GroupId, result.SentCount, elapsedMs);
+                    "Group email sent successfully. logId={LogId}, group={GroupId}, count={Count}, elapsedMs={Elapsed}",
+                    result.LogId, request.GroupId, result.SentCount, elapsedMs);
 
-                return Ok(new { message = "sent", count = result.SentCount });
+                return Ok(new { message = "sent", count = result.SentCount, logId = result.LogId });
             }
 
-            _logger.LogWarning("Group email notify failed: {Error}", result.Error);
+            _logger.LogWarning("Group email notify failed: {Error}, logId={LogId}", result.Error, result.LogId);
 
             return StatusCode(StatusCodes.Status400BadRequest, new
             {
                 message = "failed",
-                error = result.Error
+                error = result.Error,
+                logId = result.LogId
             });
         }
         catch (OperationCanceledException)

--- a/WeYuTelegramNotify/Models/EmailModels/EmailLog.cs
+++ b/WeYuTelegramNotify/Models/EmailModels/EmailLog.cs
@@ -33,7 +33,4 @@ public class EmailLog
 
     /// <summary>建立時間（UTC）。</summary>
     public DateTime CREATED_AT { get; set; }
-
-    /// <summary>實際寄出時間（UTC）。</summary>
-    public DateTime? SENT_AT { get; set; }
 }

--- a/WeYuTelegramNotify/Models/EmailModels/EmailLog.cs
+++ b/WeYuTelegramNotify/Models/EmailModels/EmailLog.cs
@@ -4,24 +4,36 @@ using WeYuTelegramNotify.Enum;
 namespace WeYuTelegramNotify.Models;
 
 /// <summary>
-/// TELEGRAM_MESSAGE_LOG table representation.
+/// EMAIL_LOG table representation.
 /// </summary>
 public class EmailLog
 {
+    /// <summary>主鍵。</summary>
     public Guid ID { get; set; }
 
+    /// <summary>
+    /// 群組 ID；若為單一收件者則為 <see cref="Guid.Empty"/>。
+    /// </summary>
     public Guid EMAIL_GROUP_ID { get; set; }
 
+    /// <summary>信件主旨。</summary>
     public string SUBJECT { get; set; } = string.Empty;
 
+    /// <summary>信件內文（HTML）。</summary>
     public string BODY { get; set; } = string.Empty;
 
-    /// <summary>0 = Queued, 1 = Success, 2 = Failed.</summary>
+    /// <summary>0 = Queued, 1 = Success, 2 = Failed。</summary>
     public SendStatus STATUS { get; set; }
 
+    /// <summary>失敗訊息。</summary>
     public string? ERROR_MESSAGE { get; set; }
 
+    /// <summary>重試次數。</summary>
     public int RETRY_COUNT { get; set; }
 
+    /// <summary>建立時間（UTC）。</summary>
     public DateTime CREATED_AT { get; set; }
+
+    /// <summary>實際寄出時間（UTC）。</summary>
+    public DateTime? SENT_AT { get; set; }
 }

--- a/WeYuTelegramNotify/Models/EmailModels/EmailSendResult.cs
+++ b/WeYuTelegramNotify/Models/EmailModels/EmailSendResult.cs
@@ -1,7 +1,15 @@
+using System;
+
 namespace WeYuTelegramNotify.Models;
 
 public class EmailSendResult
 {
+    /// <summary>是否寄送成功。</summary>
     public bool Success { get; init; }
+
+    /// <summary>失敗訊息。</summary>
     public string? Error { get; init; }
+
+    /// <summary>資料庫 Log 主鍵。</summary>
+    public Guid? LogId { get; init; }
 }

--- a/WeYuTelegramNotify/Models/EmailModels/GroupEmailSendResult.cs
+++ b/WeYuTelegramNotify/Models/EmailModels/GroupEmailSendResult.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace WeYuTelegramNotify.Models;
 
 /// <summary>
@@ -19,5 +21,8 @@ public class GroupEmailSendResult
     /// 失敗時的錯誤訊息。
     /// </summary>
     public string? Error { get; init; }
+
+    /// <summary>資料庫 Log 主鍵。</summary>
+    public Guid? LogId { get; init; }
 }
 

--- a/WeYuTelegramNotify/Program.cs
+++ b/WeYuTelegramNotify/Program.cs
@@ -68,6 +68,7 @@ public class Program
 
         builder.Services.AddScoped<ITelegramRepository, TelegramRepository>();
         builder.Services.AddScoped<IEmailGroupRepository, EmailGroupRepository>();
+        builder.Services.AddScoped<IEmailLogRepository, EmailLogRepository>();
         builder.Services.AddScoped<ITelegramNotifyService, TelegramNotifyService>();
         builder.Services.AddScoped<IEmailNotifyService, EmailNotifyService>();
 

--- a/WeYuTelegramNotify/Repositories/EmailLogRepository.cs
+++ b/WeYuTelegramNotify/Repositories/EmailLogRepository.cs
@@ -33,9 +33,9 @@ public class EmailLogRepository : IEmailLogRepository
 
         const string sql = @"
 INSERT INTO EMAIL_LOG
-    (ID, EMAIL_GROUP_ID, SUBJECT, BODY, STATUS, ERROR_MESSAGE, RETRY_COUNT, CREATED_AT, SENT_AT)
+    (ID, EMAIL_GROUP_ID, SUBJECT, BODY, STATUS, ERROR_MESSAGE, RETRY_COUNT, CREATED_AT)
 VALUES
-    (@ID, @EMAIL_GROUP_ID, @SUBJECT, @BODY, @STATUS, @ERROR_MESSAGE, @RETRY_COUNT, @CREATED_AT, @SENT_AT)";
+    (@ID, @EMAIL_GROUP_ID, @SUBJECT, @BODY, @STATUS, @ERROR_MESSAGE, @RETRY_COUNT, @CREATED_AT)";
 
         await _con.ExecuteAsync(new CommandDefinition(sql, log, cancellationToken: cancellationToken)).ConfigureAwait(false);
         return log.ID;
@@ -46,8 +46,8 @@ VALUES
         await EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
 
         const string sql = @"UPDATE EMAIL_LOG
-                             SET STATUS = @Status, ERROR_MESSAGE = @ErrorMessage, SENT_AT = @SentAt
+                             SET STATUS = @Status, ERROR_MESSAGE = @ErrorMessage
                              WHERE ID = @Id";
-        await _con.ExecuteAsync(new CommandDefinition(sql, new { Id = id, Status = status, ErrorMessage = errorMessage, SentAt = sentAt }, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        await _con.ExecuteAsync(new CommandDefinition(sql, new { Id = id, Status = status, ErrorMessage = errorMessage }, cancellationToken: cancellationToken)).ConfigureAwait(false);
     }
 }

--- a/WeYuTelegramNotify/Repositories/EmailLogRepository.cs
+++ b/WeYuTelegramNotify/Repositories/EmailLogRepository.cs
@@ -1,0 +1,53 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using WeYuTelegramNotify.Models;
+
+namespace WeYuTelegramNotify.Repositories;
+
+/// <summary>
+/// Dapper based implementation for <see cref="IEmailLogRepository"/>.
+/// </summary>
+public class EmailLogRepository : IEmailLogRepository
+{
+    private readonly SqlConnection _con;
+
+    public EmailLogRepository(SqlConnection con)
+    {
+        _con = con;
+    }
+
+    private async Task EnsureConnectionAsync(CancellationToken cancellationToken)
+    {
+        if (_con.State != ConnectionState.Open)
+        {
+            await _con.OpenAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<Guid> InsertLogAsync(EmailLog log, CancellationToken cancellationToken = default)
+    {
+        await EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        log.ID = log.ID == Guid.Empty ? Guid.NewGuid() : log.ID;
+
+        const string sql = @"
+INSERT INTO EMAIL_LOG
+    (ID, EMAIL_GROUP_ID, SUBJECT, BODY, STATUS, ERROR_MESSAGE, RETRY_COUNT, CREATED_AT, SENT_AT)
+VALUES
+    (@ID, @EMAIL_GROUP_ID, @SUBJECT, @BODY, @STATUS, @ERROR_MESSAGE, @RETRY_COUNT, @CREATED_AT, @SENT_AT)";
+
+        await _con.ExecuteAsync(new CommandDefinition(sql, log, cancellationToken: cancellationToken)).ConfigureAwait(false);
+        return log.ID;
+    }
+
+    public async Task UpdateLogStatusAsync(Guid id, byte status, string? errorMessage, DateTime? sentAt, CancellationToken cancellationToken = default)
+    {
+        await EnsureConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        const string sql = @"UPDATE EMAIL_LOG
+                             SET STATUS = @Status, ERROR_MESSAGE = @ErrorMessage, SENT_AT = @SentAt
+                             WHERE ID = @Id";
+        await _con.ExecuteAsync(new CommandDefinition(sql, new { Id = id, Status = status, ErrorMessage = errorMessage, SentAt = sentAt }, cancellationToken: cancellationToken)).ConfigureAwait(false);
+    }
+}

--- a/WeYuTelegramNotify/Repositories/IEmailLogRepository.cs
+++ b/WeYuTelegramNotify/Repositories/IEmailLogRepository.cs
@@ -1,0 +1,17 @@
+using WeYuTelegramNotify.Models;
+
+namespace WeYuTelegramNotify.Repositories;
+
+/// <summary>
+/// Data access methods for EMAIL_LOG table.
+/// </summary>
+public interface IEmailLogRepository
+{
+    /// <summary>新增一筆寄信紀錄。</summary>
+    Task<Guid> InsertLogAsync(EmailLog log, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 更新寄信狀態與錯誤資訊。
+    /// </summary>
+    Task UpdateLogStatusAsync(Guid id, byte status, string? errorMessage, DateTime? sentAt, CancellationToken cancellationToken = default);
+}

--- a/WeYuTelegramNotify/Services/EmailNotifyService.cs
+++ b/WeYuTelegramNotify/Services/EmailNotifyService.cs
@@ -26,6 +26,12 @@ public class EmailNotifyService : IEmailNotifyService
         _logRepository = logRepository;
     }
 
+    /// <summary>
+    /// 單發
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public async Task<EmailSendResult> SendAsync(EmailNotifyRequest request, CancellationToken cancellationToken = default)
     {
         Guid? logId = null;
@@ -77,6 +83,12 @@ public class EmailNotifyService : IEmailNotifyService
         }
     }
 
+    /// <summary>
+    /// 群發
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public async Task<GroupEmailSendResult> SendGroupAsync(GroupEmailNotifyRequest request, CancellationToken cancellationToken = default)
     {
         Guid? logId = null;

--- a/WeYuTelegramNotify/Services/TelegramNotifyService.cs
+++ b/WeYuTelegramNotify/Services/TelegramNotifyService.cs
@@ -88,6 +88,7 @@ public class TelegramNotifyService : ITelegramNotifyService
             var header = string.IsNullOrWhiteSpace(subject) ? string.Empty : $"<b>{subject}</b>\n\n";
             var maxBodyLength = Math.Max(0, MaxMessageLength - header.Length);
 
+            // 因為 4096 關係 所以才分段
             foreach (var chunk in SplitMessageSafe(body, maxBodyLength))
             {
                 var payload = new Dictionary<string, string>


### PR DESCRIPTION
## Summary
- add email log repository and model updates
- record log entries for single and group email send operations
- expose log ids in API responses

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b122935c9c83208db01ddf8f152db2